### PR TITLE
OMK -> OSM Submission

### DIFF
--- a/api/odk/controllers/get-osm-submissions.js
+++ b/api/odk/controllers/get-osm-submissions.js
@@ -1,7 +1,4 @@
-var fs = require('fs');
-var settings = require('../../../settings');
 var aggregateOsm = require('../osm/aggregate-osm');
-
 var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
 
 /**

--- a/api/odk/controllers/get-osm-submissions.js
+++ b/api/odk/controllers/get-osm-submissions.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var settings = require('../../../settings');
 var aggregateOsm = require('../osm/aggregate-osm');
 
-var getOsmSubmissionsFiles = require('../helpers/get-osm-submissions-files');
+var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
 
 /**
  * Aggregates together all of the OSM submissions
@@ -12,12 +12,12 @@ var getOsmSubmissionsFiles = require('../helpers/get-osm-submissions-files');
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
 
-    getOsmSubmissionsFiles(formName, function (err, osmFiles) {
+    getOsmSubmissionsDirs(formName, function (err, osmDirs) {
         if (err) {
             res.status(err.status || 500).json(err);
             return;
         }
-        aggregate(osmFiles,  req, res);
+        aggregate(osmDirs,  req, res);
     });
 
 };
@@ -26,11 +26,15 @@ module.exports = function (req, res, next) {
  * Calls aggregate-osm middleware to read OSM edit files
  * and concatenate into a single OSM XML aggregation.
  *
- * @param osmFiles  - the JOSM OSM XML edits to aggregate
+ * @param osmDirs  - submission dirs with array of osm files
  * @param req       - the http request
  * @param res       - the http response
  */
-function aggregate(osmFiles, req, res) {
+function aggregate(osmDirs, req, res) {
+    var osmFiles = [];
+    for (var d in osmDirs) {
+        osmFiles = osmFiles.concat(osmDirs[d]);
+    }
     //We filter by the query parameters of the request
     aggregateOsm(osmFiles, req.query, function (err, osmXml) {
         if (err) {

--- a/api/odk/controllers/get-osm-submissions.js
+++ b/api/odk/controllers/get-osm-submissions.js
@@ -9,7 +9,7 @@ var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
 
-    getOsmSubmissionsDirs(formName, function (err, osmDirs) {
+    getOsmSubmissionsDirs(formName, null, function (err, osmDirs) {
         if (err) {
             res.status(err.status || 500).json(err);
             return;

--- a/api/odk/controllers/get-osm-submissions.js
+++ b/api/odk/controllers/get-osm-submissions.js
@@ -2,6 +2,8 @@ var fs = require('fs');
 var settings = require('../../../settings');
 var aggregateOsm = require('../osm/aggregate-osm');
 
+var getOsmSubmissionsFiles = require('../helpers/get-osm-submissions-files');
+
 /**
  * Aggregates together all of the OSM submissions
  * from ODK Collect / OpenMapKit Android to the
@@ -9,103 +11,16 @@ var aggregateOsm = require('../osm/aggregate-osm');
  */
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
-    if (typeof formName === 'undefined' || formName === null) {
-        res.status(400).json({
-            status: 400,
-            err: 'MISSING_PARAM',
-            msg: 'You must specify a parameter for the formName in this end point.',
-            path: '/odk/submissions/:formName.osm'
-        });
-    }
-    var dir = settings.dataDir + '/submissions/' + formName;
-    var osmFiles = [];
 
-    // All of the submission dirs in the form directory
-    fs.readdir(dir, function (err, submissionDirs) {
+    getOsmSubmissionsFiles(formName, function (err, osmFiles) {
         if (err) {
-            if (err.errno === -2) {
-                // trying to open a directory that is not there.
-                res.status(404).json({
-                    status: 404,
-                    msg: 'You are trying to receive aggregated OSM submissions from a form that does not exist or has no submissions. You may have misspelled the name of the form you are looking for. The name that you specified is: ' + formName,
-                    err: err
-                });
-                return;
-            }
-            res.status(500).json({
-                status: 500,
-                msg: 'Problem reading submissionDirs.',
-                err: err
-            });
+            res.status(err.status || 500).json(err);
             return;
         }
-        var len = submissionDirs.length;
-        if (len === 0) {
-            res.status(200).json([]);
-            return;
-        }
-
-        // A structure to keep track of where we are while traversing directories
-        // to find OSM files.
-        var dirStat = {
-            len: len,
-            count: 0
-        };
-
-        for (var i = 0; i < len; i++) {
-            dirStat.submissionDir = submissionDirs[i];
-            dirStat.fullPath = dir + '/' + submissionDirs[i];
-            if (dirStat.submissionDir[0] === '.') {
-                ++dirStat.count;
-                if (len === dirStat.count) {
-                    aggregate(osmFiles, req, res);
-                }
-                continue;
-            }
-            findOsmFilesInDir(dirStat, osmFiles, req, res);
-        }
+        aggregate(osmFiles,  req, res);
     });
+
 };
-
-/**
- * Reads through all of the files in a submission directory and
- * appends the full OSM file path to the osmFiles array.
- *
- * @param dirStat  - the counters and paths of the directory we are async iterating through
- * @param osmFiles - all of the osm files we've found so far
- * @param req      = the http request
- * @param res      - the http response that needs to get resolved
- */
-function findOsmFilesInDir(dirStat, osmFiles, req, res) {
-    var fullPath = dirStat.fullPath;
-    fs.readdir(fullPath, function (err, files) {
-        if (err) {
-            // trying to open a file instead of a directory, just continue on...
-            if (err.errno === -20) {
-                ++dirStat.count;
-                return;
-            }
-            if (!res._headerSent) { // prevents trying to send multiple error responses on a single request
-                res.status(500).json({
-                    status: 500,
-                    msg: 'There was a problem with reading the OSM files in the submissions directory.',
-                    err: err
-                });
-            }
-            return;
-        }
-        ++dirStat.count;
-        for (var j = 0, len = files.length; j < len; j++) {
-            var file = files[j];
-            if (file.substring(file.length - 4) !== '.osm') continue; // Check if .osm file
-            var longFilePath = fullPath + '/' + file;
-            osmFiles.push(longFilePath);
-        }
-        if (dirStat.len === dirStat.count) {
-            aggregate(osmFiles, req, res);
-        }
-    });
-}
 
 /**
  * Calls aggregate-osm middleware to read OSM edit files

--- a/api/odk/controllers/patch-submissions.js
+++ b/api/odk/controllers/patch-submissions.js
@@ -22,19 +22,15 @@ var appendFileDeferred = function(filePath, append) {
 };
 
 module.exports = function(req, res, next){
-
-    var err;
-
     var formName = path.basename(req.params.formName);
 
     var entityChecksums = req.body.finalizedOsmChecksums || null;
 
     if(!entityChecksums || !entityChecksums instanceof Array) {
-        err = new Error('Bad Request: finalizedOsmChecksums must be a string array.');
+        var err = new Error('Bad Request: finalizedOsmChecksums must be a string array.');
         err.status = 400;
         next(err);
     }
-
 
     // Get the current blacklist
     var blacklist = checksumHelper.get(formName) || null;

--- a/api/odk/controllers/patch-submissions.js
+++ b/api/odk/controllers/patch-submissions.js
@@ -33,14 +33,7 @@ module.exports = function(req, res, next){
     }
 
     // Get the current blacklist
-    var blacklist = checksumHelper.get(formName) || null;
-
-    // If the form not yet added to the formHash map, then we need to add it and create an empty blacklist
-    if(!blacklist) {
-        var formHash = checksumHelper.get();
-        formHash.set(formName, new Map());
-        blacklist = formHash.get(formName);
-    }
+    var blacklist = checksumHelper.get(formName);
 
     // Parallel async call to find and append the finialized-osm-checksum.txt files that managed the patched checksums
     Q.all(entityChecksums.map(function(checksum){

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -1,0 +1,3 @@
+module.exports = function (req, res, next) {
+
+};

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -1,4 +1,20 @@
+var submitChangesets = require('../osm/submit-changesets');
+
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
-    
+
+    var osmApi = {
+        server: req.query.server || req.body.server || 'https://www.openstreetmap.org/api',
+        user: req.query.user || req.body.user,
+        password: req.query.password || req.query.password
+    };
+
+    submitChangesets(formName, osmApi, function (err, status) {
+        if (err) {
+            res.status(err.status || 500).json(err);
+            return;
+        }
+        res.status(200).json(status);
+    });
+
 };

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -1,10 +1,9 @@
 var submitAllChangesets = require('../osm/submit-changesets').submitAllChangesetsForForm;
-var osmApi = require('../../../settings').osmApi;
 
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
 
-    submitAllChangesets(formName, osmApi, function (err, status) {
+    submitAllChangesets(formName, function (err, status) {
         if (!res._headerSent) { // prevents trying to send multiple error responses on a single request
             if (err) {
                 res.status(err.status || 500).json(err);

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -6,7 +6,7 @@ module.exports = function (req, res, next) {
     var osmApi = {
         server: req.query.server || req.body.server || 'https://www.openstreetmap.org/api',
         user: req.query.user || req.body.user,
-        password: req.query.password || req.query.password
+        pass: req.query.pass || req.query.pass
     };
 
     submitChangesets(formName, osmApi, function (err, status) {

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -13,6 +13,15 @@ module.exports = function (req, res, next) {
             res.status(status.status || 200).json(status);
         } else {
             // notify via web socket
+
+            // log events
+            if (err) {
+                console.error(JSON.stringify(err));
+                return;
+            }
+            if (status) {
+                console.log(JSON.stringify(status));
+            }
         }
     });
 

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -1,3 +1,4 @@
 module.exports = function (req, res, next) {
-
+    var formName = req.params.formName;
+    
 };

--- a/api/odk/controllers/submit-changesets.js
+++ b/api/odk/controllers/submit-changesets.js
@@ -1,20 +1,19 @@
-var submitChangesets = require('../osm/submit-changesets');
+var submitAllChangesets = require('../osm/submit-changesets').submitAllChangesetsForForm;
+var osmApi = require('../../../settings').osmApi;
 
 module.exports = function (req, res, next) {
     var formName = req.params.formName;
 
-    var osmApi = {
-        server: req.query.server || req.body.server || 'https://www.openstreetmap.org/api',
-        user: req.query.user || req.body.user,
-        pass: req.query.pass || req.query.pass
-    };
-
-    submitChangesets(formName, osmApi, function (err, status) {
-        if (err) {
-            res.status(err.status || 500).json(err);
-            return;
+    submitAllChangesets(formName, osmApi, function (err, status) {
+        if (!res._headerSent) { // prevents trying to send multiple error responses on a single request
+            if (err) {
+                res.status(err.status || 500).json(err);
+                return;
+            }
+            res.status(status.status || 200).json(status);
+        } else {
+            // notify via web socket
         }
-        res.status(200).json(status);
     });
 
 };

--- a/api/odk/helpers/checksum-hash.js
+++ b/api/odk/helpers/checksum-hash.js
@@ -108,3 +108,13 @@ module.exports.get = function(formName){
     }
     return blacklist;
 };
+
+/**
+ * Adds a set of checksums to the blacklist hash and file.
+ * 
+ * @param formName
+ * @param finalizedOsmChecksums
+ */
+module.exports.addFinalizedChecksums = function (formName, finalizedOsmChecksums) {
+     
+};

--- a/api/odk/helpers/checksum-hash.js
+++ b/api/odk/helpers/checksum-hash.js
@@ -101,10 +101,10 @@ module.exports.create = function(cb){
     });
 };
 module.exports.get = function(formName){
-
-    if(formName === undefined) {
-        return formHash;
+    var blacklist = formHash.get(formName);
+    if(!blacklist) {
+        blacklist = new Map();
+        formHash.set(formName, blacklist);
     }
-
-    return formHash.get(formName);
+    return blacklist;
 };

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -3,9 +3,12 @@ var settings = require('../../../settings');
 
 /**
  * Gathers all of the OSM submissions for a form.
+ * Creates an object with the submissions dir
+ * and an array of corresponding files.
  * 
  * @param formName - the name (form_id) of the ODK form
- * @param cb - first param is error, second is array of osm files
+ * @param cb - first param is error, second is an object of submission dirs
+ *             with an array of osm files
  */
 module.exports = function (formName, cb) {
     if (typeof formName === 'undefined' || formName === null) {
@@ -70,10 +73,10 @@ module.exports = function (formName, cb) {
  * appends the full OSM file path to the osmFiles array.
  *
  * @param dirStat  - the counters and paths of the directory we are async iterating through
- * @param osmFiles - all of the osm files we've found so far
+ * @param osmDirs - all of the osm files we've found so far, grouped by the submission dir
  * @param cb - first param is error, second is array of osm files
  */
-function findOsmFilesInDir(dirStat, osmFiles, cb) {
+function findOsmFilesInDir(dirStat, osmDirs, cb) {
     var fullPath = dirStat.fullPath;
     fs.readdir(fullPath, function (err, files) {
         if (err) {
@@ -96,10 +99,13 @@ function findOsmFilesInDir(dirStat, osmFiles, cb) {
             var file = files[j];
             if (file.substring(file.length - 4) !== '.osm') continue; // Check if .osm file
             var longFilePath = fullPath + '/' + file;
-            osmFiles.push(longFilePath);
+            if (typeof osmDirs[fullPath] !== 'object') { // arrays are objects
+                osmDirs[fullPath] = [];
+            }
+            osmDirs[fullPath].push(longFilePath);
         }
         if (dirStat.len === dirStat.count) {
-            cb(null, osmFiles)
+            cb(null, osmDirs)
         }
     });
 }

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -19,7 +19,7 @@ module.exports = function (formName, options, cb) {
         });
     }
     var dir = settings.dataDir + '/submissions/' + formName;
-    var osmDirs = {};
+    var osmDirs = [];
 
     // All of the submission dirs in the form directory
     fs.readdir(dir, function (err, submissionDirs) {
@@ -96,20 +96,22 @@ function findOsmFilesInDir(dirStat, osmDirs, options, cb) {
             return;
         }
         ++dirStat.count;
+        var dirObj = {dir: fullPath, files: []}; // obj to be added to osmDirs array
+        var skip = false; // determines if we should add to osmDirs array
         for (var j = 0, len = files.length; j < len; j++) {
             var file = files[j];
             if (typeof options === 'object' && options != null && options.unsubmittedOnly) {
                 if (file.indexOf('diffResult') === 0 || file.indexOf('conflict') === 0) {
-                    delete osmDirs[fullPath];
+                    skip = true;
                     break;
                 }
             }
             if (file.substring(file.length - 4) !== '.osm') continue; // Check if .osm file
             var longFilePath = fullPath + '/' + file;
-            if (typeof osmDirs[fullPath] !== 'object') { // arrays are objects
-                osmDirs[fullPath] = [];
-            }
-            osmDirs[fullPath].push(longFilePath);
+            dirObj.files.push(longFilePath);
+        }
+        if (!skip) {
+            osmDirs.push(dirObj);
         }
         if (dirStat.len === dirStat.count) {
             cb(null, osmDirs)

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -99,7 +99,7 @@ function findOsmFilesInDir(dirStat, osmDirs, options, cb) {
         for (var j = 0, len = files.length; j < len; j++) {
             var file = files[j];
             if (typeof options === 'object' && options != null && options.unsubmittedOnly) {
-                if (file === 'diffResult.xml' || file === 'conflict.json') {
+                if (file.indexOf('diffResult') === 0 || file.indexOf('conflict') === 0) {
                     delete osmDirs[fullPath];
                     break;
                 }

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -99,7 +99,7 @@ function findOsmFilesInDir(dirStat, osmDirs, options, cb) {
         for (var j = 0, len = files.length; j < len; j++) {
             var file = files[j];
             if (typeof options === 'object' && options != null && options.unsubmittedOnly) {
-                if (file === 'diffResult.xml') {
+                if (file === 'diffResult.xml' || file === 'conflict.json') {
                     delete osmDirs[fullPath];
                     break;
                 }

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -111,7 +111,9 @@ function findOsmFilesInDir(dirStat, osmDirs, options, cb) {
             dirObj.files.push(longFilePath);
         }
         if (!skip) {
-            osmDirs.push(dirObj);
+            if (dirObj.files.length > 0) {
+                osmDirs.push(dirObj);    
+            }
         }
         if (dirStat.len === dirStat.count) {
             cb(null, osmDirs)

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -10,7 +10,7 @@ var settings = require('../../../settings');
  * @param cb - first param is error, second is an object of submission dirs
  *             with an array of osm files
  */
-module.exports = function (formName, cb) {
+module.exports = function (formName, options, cb) {
     if (typeof formName === 'undefined' || formName === null) {
         cb({
             status: 400,
@@ -63,7 +63,7 @@ module.exports = function (formName, cb) {
                 }
                 continue;
             }
-            findOsmFilesInDir(dirStat, osmDirs, cb);
+            findOsmFilesInDir(dirStat, osmDirs, options, cb);
         }
     });
 };
@@ -74,9 +74,10 @@ module.exports = function (formName, cb) {
  *
  * @param dirStat  - the counters and paths of the directory we are async iterating through
  * @param osmDirs - all of the osm files we've found so far, grouped by the submission dir
+ * @param options - options regarding what to include
  * @param cb - first param is error, second is array of osm files
  */
-function findOsmFilesInDir(dirStat, osmDirs, cb) {
+function findOsmFilesInDir(dirStat, osmDirs, options, cb) {
     var fullPath = dirStat.fullPath;
     fs.readdir(fullPath, function (err, files) {
         if (err) {
@@ -97,6 +98,12 @@ function findOsmFilesInDir(dirStat, osmDirs, cb) {
         ++dirStat.count;
         for (var j = 0, len = files.length; j < len; j++) {
             var file = files[j];
+            if (typeof options === 'object' && options != null && options.unsubmittedOnly) {
+                if (file === 'diffResult.xml') {
+                    delete osmDirs[fullPath];
+                    break;
+                }
+            }
             if (file.substring(file.length - 4) !== '.osm') continue; // Check if .osm file
             var longFilePath = fullPath + '/' + file;
             if (typeof osmDirs[fullPath] !== 'object') { // arrays are objects

--- a/api/odk/helpers/get-osm-submissions-dirs.js
+++ b/api/odk/helpers/get-osm-submissions-dirs.js
@@ -19,7 +19,7 @@ module.exports = function (formName, cb) {
         });
     }
     var dir = settings.dataDir + '/submissions/' + formName;
-    var osmFiles = [];
+    var osmDirs = {};
 
     // All of the submission dirs in the form directory
     fs.readdir(dir, function (err, submissionDirs) {
@@ -59,11 +59,11 @@ module.exports = function (formName, cb) {
             if (dirStat.submissionDir[0] === '.') {
                 ++dirStat.count;
                 if (len === dirStat.count) {
-                    cb(null, osmFiles);
+                    cb(null, osmDirs);
                 }
                 continue;
             }
-            findOsmFilesInDir(dirStat, osmFiles, cb);
+            findOsmFilesInDir(dirStat, osmDirs, cb);
         }
     });
 };

--- a/api/odk/helpers/get-osm-submissions-files.js
+++ b/api/odk/helpers/get-osm-submissions-files.js
@@ -1,0 +1,105 @@
+var fs = require('fs');
+var settings = require('../../../settings');
+
+/**
+ * Gathers all of the OSM submissions for a form.
+ * 
+ * @param formName - the name (form_id) of the ODK form
+ * @param cb - first param is error, second is array of osm files
+ */
+module.exports = function (formName, cb) {
+    if (typeof formName === 'undefined' || formName === null) {
+        cb({
+            status: 400,
+            err: 'MISSING_PARAM',
+            msg: 'You must specify a parameter for the formName.'
+        });
+    }
+    var dir = settings.dataDir + '/submissions/' + formName;
+    var osmFiles = [];
+
+    // All of the submission dirs in the form directory
+    fs.readdir(dir, function (err, submissionDirs) {
+        if (err) {
+            if (err.errno === -2) {
+                // trying to open a directory that is not there.
+                cb({
+                    status: 404,
+                    msg: 'You are trying to get OSM submissions from a form that does not exist or has no submissions. You may have misspelled the name of the form you are looking for. The name that you specified is: ' + formName,
+                    err: err
+                });
+                return;
+            }
+            cb({
+                status: 500,
+                msg: 'Problem reading submissionDirs.',
+                err: err
+            });
+            return;
+        }
+        var len = submissionDirs.length;
+        if (len === 0) {
+            cb(null, []);
+            return;
+        }
+
+        // A structure to keep track of where we are while traversing directories
+        // to find OSM files.
+        var dirStat = {
+            len: len,
+            count: 0
+        };
+
+        for (var i = 0; i < len; i++) {
+            dirStat.submissionDir = submissionDirs[i];
+            dirStat.fullPath = dir + '/' + submissionDirs[i];
+            if (dirStat.submissionDir[0] === '.') {
+                ++dirStat.count;
+                if (len === dirStat.count) {
+                    cb(null, osmFiles);
+                }
+                continue;
+            }
+            findOsmFilesInDir(dirStat, osmFiles, cb);
+        }
+    });
+};
+
+/**
+ * Reads through all of the files in a submission directory and
+ * appends the full OSM file path to the osmFiles array.
+ *
+ * @param dirStat  - the counters and paths of the directory we are async iterating through
+ * @param osmFiles - all of the osm files we've found so far
+ * @param cb - first param is error, second is array of osm files
+ */
+function findOsmFilesInDir(dirStat, osmFiles, cb) {
+    var fullPath = dirStat.fullPath;
+    fs.readdir(fullPath, function (err, files) {
+        if (err) {
+            // trying to open a file instead of a directory, just continue on...
+            if (err.errno === -20) {
+                ++dirStat.count;
+                return;
+            }
+            if (!res._headerSent) { // prevents trying to send multiple error responses on a single request
+                res.status(500).json({
+                    status: 500,
+                    msg: 'There was a problem with reading the OSM files in the submissions directory.',
+                    err: err
+                });
+            }
+            return;
+        }
+        ++dirStat.count;
+        for (var j = 0, len = files.length; j < len; j++) {
+            var file = files[j];
+            if (file.substring(file.length - 4) !== '.osm') continue; // Check if .osm file
+            var longFilePath = fullPath + '/' + file;
+            osmFiles.push(longFilePath);
+        }
+        if (dirStat.len === dirStat.count) {
+            cb(null, osmFiles)
+        }
+    });
+}

--- a/api/odk/middlewares/save-media.js
+++ b/api/odk/middlewares/save-media.js
@@ -60,7 +60,7 @@ function SaveMedia (options) {
                 if (taskCount < req.files.length) return;
                 cleanupFiles();
                 if (Object.keys(osmDirs).length > 0) {
-                    createAndSubmitChangesets(osmDirs, settings.osmApi);
+                    // createAndSubmitChangesets(osmDirs);
                 }
                 next();
             });

--- a/api/odk/middlewares/save-media.js
+++ b/api/odk/middlewares/save-media.js
@@ -2,6 +2,7 @@ var extend = require('xtend');
 var fs = require('fs');
 var persistFs = require('../helpers/persist');
 var updateFileRef = require('../helpers/update-file-ref');
+var createAndSubmitChangesets = require('../osm/submit-changesets').createAndSubmitChangesets;
 var settings = require('../../../settings.js');
 
 var defaults = {
@@ -26,6 +27,10 @@ function SaveMedia (options) {
 
         var taskCount = 0;
 
+        // Used to submit changesets for the osm files being submitted
+        // in osm/submit-changesets.js
+        var osmDirs = {};
+
         req.files.forEach(function (file) {
             var storeOptions = {
                 filename: req.submission.instanceId + '/' + file.originalFilename,
@@ -34,6 +39,12 @@ function SaveMedia (options) {
                     path: settings.dataDir + '/submissions/' + req.submission.formId + '/'
                 }
             };
+
+            // Create OSM hash used by osm/submit-changesets.js
+            if (file.substring(file.length - 4) === '.osm') {
+                var pwd = storeOptions.filesystem.path + req.submission.instanceId;
+                osmDirs[pwd] = pwd + '/' + file;
+            }
 
             store(fs.createReadStream(file.path), storeOptions, function onSave (err, url) {
                 if (err) onError(err);
@@ -44,6 +55,7 @@ function SaveMedia (options) {
                 // Quick and dirty check whether we have processed all the files
                 if (taskCount < req.files.length) return;
                 cleanupFiles();
+                createAndSubmitChangesets(osmDirs, settings.osmApi);
                 next();
             });
         });

--- a/api/odk/middlewares/save-media.js
+++ b/api/odk/middlewares/save-media.js
@@ -42,9 +42,12 @@ function SaveMedia (options) {
 
             // Create OSM hash used by osm/submit-changesets.js
             var fileName = file.fieldName;
-            if (fileName.substring(file.length - 4) === '.osm') {
+            if (fileName.substring(fileName.length - 4) === '.osm') {
                 var pwd = storeOptions.filesystem.path + req.submission.instanceId;
-                osmDirs[pwd] = pwd + '/' + fileName;
+                if (typeof osmDirs[pwd] !== 'object') {
+                    osmDirs[pwd] = [];
+                }
+                osmDirs[pwd].push(pwd + '/' + fileName);
             }
 
             store(fs.createReadStream(file.path), storeOptions, function onSave (err, url) {
@@ -56,7 +59,9 @@ function SaveMedia (options) {
                 // Quick and dirty check whether we have processed all the files
                 if (taskCount < req.files.length) return;
                 cleanupFiles();
-                // createAndSubmitChangesets(osmDirs, settings.osmApi);
+                if (Object.keys(osmDirs).length > 0) {
+                    createAndSubmitChangesets(osmDirs, settings.osmApi);
+                }
                 next();
             });
         });

--- a/api/odk/middlewares/save-media.js
+++ b/api/odk/middlewares/save-media.js
@@ -29,7 +29,11 @@ function SaveMedia (options) {
 
         // Used to submit changesets for the osm files being submitted
         // in osm/submit-changesets.js
-        var osmDirs = {};
+        var dir = settings.dataDir + '/submissions/' + req.submission.formId + '/' + req.submission.instanceId;
+        var dirObj = {
+            dir: dir,
+            files: []
+        };
 
         req.files.forEach(function (file) {
             var storeOptions = {
@@ -43,11 +47,7 @@ function SaveMedia (options) {
             // Create OSM hash used by osm/submit-changesets.js
             var fileName = file.fieldName;
             if (fileName.substring(fileName.length - 4) === '.osm') {
-                var pwd = storeOptions.filesystem.path + req.submission.instanceId;
-                if (typeof osmDirs[pwd] !== 'object') {
-                    osmDirs[pwd] = [];
-                }
-                osmDirs[pwd].push(pwd + '/' + fileName);
+                dirObj.files.push(dir + '/' + fileName);
             }
 
             store(fs.createReadStream(file.path), storeOptions, function onSave (err, url) {
@@ -59,8 +59,8 @@ function SaveMedia (options) {
                 // Quick and dirty check whether we have processed all the files
                 if (taskCount < req.files.length) return;
                 cleanupFiles();
-                if (Object.keys(osmDirs).length > 0) {
-                    // createAndSubmitChangesets(osmDirs);
+                if (dirObj.files.length > 0) {
+                    createAndSubmitChangesets([dirObj]);
                 }
                 next();
             });

--- a/api/odk/middlewares/save-media.js
+++ b/api/odk/middlewares/save-media.js
@@ -41,9 +41,10 @@ function SaveMedia (options) {
             };
 
             // Create OSM hash used by osm/submit-changesets.js
-            if (file.substring(file.length - 4) === '.osm') {
+            var fileName = file.fieldName;
+            if (fileName.substring(file.length - 4) === '.osm') {
                 var pwd = storeOptions.filesystem.path + req.submission.instanceId;
-                osmDirs[pwd] = pwd + '/' + file;
+                osmDirs[pwd] = pwd + '/' + fileName;
             }
 
             store(fs.createReadStream(file.path), storeOptions, function onSave (err, url) {
@@ -55,7 +56,7 @@ function SaveMedia (options) {
                 // Quick and dirty check whether we have processed all the files
                 if (taskCount < req.files.length) return;
                 cleanupFiles();
-                createAndSubmitChangesets(osmDirs, settings.osmApi);
+                // createAndSubmitChangesets(osmDirs, settings.osmApi);
                 next();
             });
         });

--- a/api/odk/odk-aggregate-routes.js
+++ b/api/odk/odk-aggregate-routes.js
@@ -4,18 +4,28 @@ var getJsonSubmissions = require('./controllers/get-json-submissions');
 var getOsmSubmissions = require('./controllers/get-osm-submissions');
 var patchSubmissions = require('./controllers/patch-submissions');
 var uploadForm = require('./controllers/upload-form');
+var submitChangesets = require('./controllers/submit-changesets');
 
 /**
  * Aggregate End Points
  */
 router.route('/submissions').get(getSubmissionsList);
 router.route('/submissions/:formName.json').get(getJsonSubmissions);
-router.route('/submissions/:formName.osm').get(getOsmSubmissions);
-router.route('/submissions/:formName.osm').patch(patchSubmissions);
+router.route('/submissions/:formName.osm')
+                .get(getOsmSubmissions)
+                .patch(patchSubmissions);
 
 /**
  * XLSForm Upload Endpoint
  */
 router.route('/upload-form').post(uploadForm);
+
+/**
+ * Creates changesets for submissions and submits to
+ * an OSM Editing API
+ */
+router.route('/submit-changesets/:formName')
+                .get(submitChangesets)
+                .put(submitChangesets);
 
 module.exports = router;

--- a/api/odk/osm/generate-changeset.js
+++ b/api/odk/osm/generate-changeset.js
@@ -4,14 +4,27 @@ var settings = require('../../../settings');
 var pkg = require('../../../package');
 
 module.exports = function (submissionsDir) {
-    var createdBy = 'OpenMapKit Server v' + pkg.version;
-    var omkPath = '';
+    var dataDir = '/omk/data' + submissionsDir.split('data')[1] + '/';
+    var dirParts = submissionsDir.split('/');
 
-    return builder.create('osm', {version: '1.0', encoding: 'UTF-8'})
+    var tags = {};
+    tags.created_by = 'OpenMapKit Server ' + pkg.version;
+    tags.type = 'survey';
+    tags.uri = dataDir + 'data.json';
+    tags.form = submissionsDir.split('submissions/')[1].split('/')[0];
+    tags.instance_id = dirParts[dirParts.length-1];
+    if (settings.hostUrl) {
+        tags.url = settings.hostUrl + tags.uri;
+    }
+    tags.comment = tags.created_by + ' ' + tags.form + ' submission. ' + tags.instance_id;
+
+    var changeset = builder.create('osm', {version: '1.0', encoding: 'UTF-8'})
         .att({version: '0.6'})
-        .ele('changeset')
-            .ele('tag', {k: 'testkey', v: 'testval'})
-            .insertAfter('tag', {k: 'testkey2', v: 'testval2'})
-        .end({ pretty: true});
+        .ele('changeset');
 
+    for (var k in tags) {
+        changeset.ele('tag', {k: k, v: tags[k]});
+    }
+    
+    return changeset.end({ pretty: true});
 };

--- a/api/odk/osm/generate-changeset.js
+++ b/api/odk/osm/generate-changeset.js
@@ -1,0 +1,7 @@
+var settings = require('../../../settings');
+var pkg = require('../../../package');
+
+module.exports = function (submissionsDir) {
+    var createdBy = 'OpenMapKit Server v' + pkg.version;
+    var omkPath = '';
+};

--- a/api/odk/osm/generate-changeset.js
+++ b/api/odk/osm/generate-changeset.js
@@ -7,10 +7,11 @@ module.exports = function (submissionsDir) {
     var createdBy = 'OpenMapKit Server v' + pkg.version;
     var omkPath = '';
 
-    return builder.create('root', {version: '1.0', encoding: 'UTF-8'})
-        .ele('osm', {version: 0.6})
-            .ele('changeset')
-                .ele('tag', {k: 'testkey', v: 'testval'})
+    return builder.create('osm', {version: '1.0', encoding: 'UTF-8'})
+        .att({version: '0.6'})
+        .ele('changeset')
+            .ele('tag', {k: 'testkey', v: 'testval'})
+            .insertAfter('tag', {k: 'testkey2', v: 'testval2'})
         .end({ pretty: true});
 
 };

--- a/api/odk/osm/generate-changeset.js
+++ b/api/odk/osm/generate-changeset.js
@@ -1,7 +1,16 @@
+var builder = require('xmlbuilder');
+
 var settings = require('../../../settings');
 var pkg = require('../../../package');
 
 module.exports = function (submissionsDir) {
     var createdBy = 'OpenMapKit Server v' + pkg.version;
     var omkPath = '';
+
+    return builder.create('root', {version: '1.0', encoding: 'UTF-8'})
+        .ele('osm', {version: 0.6})
+            .ele('changeset')
+                .ele('tag', {k: 'testkey', v: 'testval'})
+        .end({ pretty: true});
+
 };

--- a/api/odk/osm/generate-changeset.js
+++ b/api/odk/osm/generate-changeset.js
@@ -2,13 +2,14 @@ var builder = require('xmlbuilder');
 
 var settings = require('../../../settings');
 var pkg = require('../../../package');
+var version = pkg.version;
 
 module.exports = function (submissionsDir) {
     var dataDir = '/omk/data' + submissionsDir.split('data')[1] + '/';
     var dirParts = submissionsDir.split('/');
 
     var tags = {};
-    tags.created_by = 'OpenMapKit Server ' + pkg.version;
+    tags.created_by = 'OpenMapKit Server ' + version;
     tags.type = 'survey';
     tags.uri = dataDir + 'data.json';
     tags.form = submissionsDir.split('submissions/')[1].split('/')[0];
@@ -26,5 +27,5 @@ module.exports = function (submissionsDir) {
         changeset.ele('tag', {k: k, v: tags[k]});
     }
     
-    return changeset.end({ pretty: true});
+    return changeset.end();
 };

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -5,7 +5,7 @@ var xml2js = require('xml2js');
 var pkg = require('../../../package');
 var version = pkg.version;
 
-module.exports = function(osmXmlFiles, cb) {
+module.exports = function(osmXmlFiles, changesetId, cb) {
 
     /**
      * This is the object used by xml2js which will
@@ -49,7 +49,7 @@ module.exports = function(osmXmlFiles, cb) {
     async.each(osmXmlFiles, function (file, cb) {
         fs.readFile(file, 'utf-8', function (err, osmXmlStr) {
             if (err) {
-                cb(err)
+                cb(err, changesetId);
             }
 
             var parser = new xml2js.Parser();
@@ -89,7 +89,7 @@ module.exports = function(osmXmlFiles, cb) {
         });
         var xml = builder.buildObject(obj);
 
-        cb(null, xml);
+        cb(null, xml, changesetId);
     });
 };
 

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -1,18 +1,123 @@
 var fs = require('fs');
 var async = require('async');
+var xml2js = require('xml2js');
+
+var pkg = require('../../../package');
+var version = pkg.version;
 
 module.exports = function(osmXmlFiles, cb) {
-    async.each(osmXmlFiles, function (file, cb) {
 
-        fs.readFile(file, 'utf-8', function (err, xml) {
-            if (err) {
-                cb(err);
-                return;
+    /**
+     * This is the object used by xml2js which will
+     * be ultimately turned into an XML string by
+     * the xml2js.Builder.
+     *
+     * @type {{osmChange: {$: {version: string, generator: string}, create: {}, modify: {}, delete: {}}}}
+     */
+    var obj = {
+        osmChange: {
+            $: {
+                version: '0.6',
+                generator: 'OpenMapKit Server ' + version
+            },
+            create: {
+                node: [],
+                way: [],
+                relation: []
+            },
+            modify: {
+                node: [],
+                way: [],
+                relation: []
+            },
+            delete: {
+                $: {
+                    'if-unused': 'true'
+                },
+                node: [],
+                way: [],
+                relation: []
             }
-            
-        });
+        }
+    };
 
-    }, function (err, oscXmlStr) {
-        cb(err, oscXmlStr);
+    /**
+     * Going through all of the OSM XML files for a submission (in parallel).
+     * Builds the OSC XML string when all of the OSM XML files are read
+     * and processed.
+     */
+    async.each(osmXmlFiles, function (file, cb) {
+        fs.readFile(file, 'utf-8', function (err, osmXmlStr) {
+            if (err) {
+                cb(err)
+            }
+
+            var parser = new xml2js.Parser();
+
+            parser.parseString(osmXmlStr, function (err, result) {
+                var osm = result.osm;
+                var nodes = osm.node || [];
+                var ways = osm.way || [];
+                var relations = osm.relation || [];
+
+                for (var i = 0, nlen = nodes.length; i < nlen; i++) {
+                    placeOsmElement(nodes[i], obj, 'node');
+                }
+                for (var j = 0, wlen = ways.length; j < wlen; j++) {
+                    placeOsmElement( ways[j], obj, 'way');
+                }
+                for (var k = 0, rlen = relations.length; k < rlen; k++) {
+                    placeOsmElement(relations[k], obj, 'relation');
+                }
+
+                cb();
+            });
+            
+
+        });
+    }, function (err) {  // Done with all of the OSM XML Files.
+        if (err) {
+            cb(err);
+            return;
+        }
+
+        var builder = new xml2js.Builder();
+        var xml = builder.buildObject(obj);
+
+        cb(null, xml);
     });
 };
+
+/**
+ * Looks at the action tag in JOSM OSM file
+ * and places it in the right osmChange node.
+ *
+ * Elements that are not modified or deleted
+ * are ignored, since they did not change.
+ *
+ * Note: OSM Elements without an action
+ *       should not make it into the osc.
+ *
+ * @param el - osm element
+ * @param obj - xml2js object
+ * @param type - type of osm element
+ */
+function placeOsmElement(el, obj, type) {
+    var action = el.$.action;
+    if (action === 'modify') {
+        // negative element means that it is new
+        if (parseInt(el.$.id) < 0) {
+            obj.osmChange.create[type].push(el);
+        }
+        // otherwise, it already exists and has been modified
+        else {
+            obj.osmChange.modify[type].push(el);
+        }
+        return;
+    }
+    if (action === 'delete') {
+        obj.osmChange.delete[type].push(el);
+    }
+    // regardless, osc doesnt have the action attribute
+    delete el.$.action;
+}

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -1,5 +1,18 @@
+var fs = require('fs');
+var async = require('async');
 
-module.exports = function(osmXmlStr) {
-    
-    return "";
+module.exports = function(osmXmlFiles, submissionsDir, cb) {
+    async.each(osmXmlFiles, function (file, cb) {
+
+        fs.readFile(file, 'utf-8', function (err, xml) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            
+        });
+
+    }, function (err, oscXmlStr) {
+        cb(err, oscXmlStr);
+    });
 };

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -1,0 +1,5 @@
+
+module.exports = function(osmXmlStr) {
+    
+    return "";
+};

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -60,13 +60,13 @@ module.exports = function(osmXmlFiles, cb) {
                 var ways = osm.way || [];
                 var relations = osm.relation || [];
 
-                for (var i = 0, nlen = nodes.length; i < nlen; i++) {
+                for (var i = 0, nlen = nodes.length; i < nlen; ++i) {
                     placeOsmElement(nodes[i], obj, 'node');
                 }
-                for (var j = 0, wlen = ways.length; j < wlen; j++) {
+                for (var j = 0, wlen = ways.length; j < wlen; ++j) {
                     placeOsmElement( ways[j], obj, 'way');
                 }
-                for (var k = 0, rlen = relations.length; k < rlen; k++) {
+                for (var k = 0, rlen = relations.length; k < rlen; ++k) {
                     placeOsmElement(relations[k], obj, 'relation');
                 }
 

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -61,13 +61,13 @@ module.exports = function(osmXmlFiles, changesetId, cb) {
                 var relations = osm.relation || [];
 
                 for (var i = 0, nlen = nodes.length; i < nlen; ++i) {
-                    placeOsmElement(nodes[i], obj, 'node');
+                    placeOsmElement(nodes[i], obj, changesetId, 'node');
                 }
                 for (var j = 0, wlen = ways.length; j < wlen; ++j) {
-                    placeOsmElement( ways[j], obj, 'way');
+                    placeOsmElement(ways[j], obj, changesetId, 'way');
                 }
                 for (var k = 0, rlen = relations.length; k < rlen; ++k) {
-                    placeOsmElement(relations[k], obj, 'relation');
+                    placeOsmElement(relations[k], obj, changesetId, 'relation');
                 }
 
                 cb();
@@ -105,9 +105,11 @@ module.exports = function(osmXmlFiles, changesetId, cb) {
  *
  * @param el - osm element
  * @param obj - xml2js object
+ * @param changesetId - the new changeset id
  * @param type - type of osm element
  */
-function placeOsmElement(el, obj, type) {
+function placeOsmElement(el, obj, changesetId, type) {
+    el.$.changeset = changesetId;
     var action = el.$.action;
     if (action === 'modify') {
         // negative element means that it is new

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var async = require('async');
 
-module.exports = function(osmXmlFiles, submissionsDir, cb) {
+module.exports = function(osmXmlFiles, cb) {
     async.each(osmXmlFiles, function (file, cb) {
 
         fs.readFile(file, 'utf-8', function (err, xml) {

--- a/api/odk/osm/osm2osc.js
+++ b/api/odk/osm/osm2osc.js
@@ -81,7 +81,12 @@ module.exports = function(osmXmlFiles, cb) {
             return;
         }
 
-        var builder = new xml2js.Builder();
+        var builder = new xml2js.Builder({
+            renderOpts: {
+                pretty: false
+            },
+            headless: true
+        });
         var xml = builder.buildObject(obj);
 
         cb(null, xml);

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -5,7 +5,7 @@ var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
 var generateChangeset = require('../osm/generate-changeset');
 var osm2osc = require('../osm/osm2osc');
 
-var NUM_PARALLEL_SUBMISSIONS = 4;
+var NUM_PARALLEL_SUBMISSIONS = 3;
 
 module.exports = {
     submitAllChangesetsForForm: submitAllChangesetsForForm,

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -41,12 +41,12 @@ function createAndSubmitChangesets(formName, osmDirs, osmApi, cb) {
                 cb(err);
                 return;
             }
-            osm2osc(osmFiles, function (err, oscXml) {
+            osm2osc(osmFiles, changesetId, function (err, oscXml, changesetId) {
                 if (err) {
                     cb(err);
                     return;
                 }
-                changesetUpload(osmApi, changesetId, oscXml, function(err, diffResult) {
+                changesetUpload(osmApi, changesetId, oscXml, function(err, diffResult, changesetId) {
                     if (err) {
                         cb(err);
                         return;
@@ -129,7 +129,7 @@ function changesetUpload(osmApi, changesetId, oscXml, cb) {
             return;
         }
         // NH TODO: Check to see if we ever try and cb something that is not a diffResult
-        cb(null, body);
+        cb(null, body, changesetId);
     });
 }
 

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -1,3 +1,38 @@
+var async = require('async');
+var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
+
+var NUM_PARALLEL_SUBMISSIONS = 4;
+
 module.exports = function (formName, osmApi, cb) {
-    
+    getOsmSubmissionsDirs(formName, function (err, osmDirs) {
+        if (err) {
+            cb(err);
+            return;
+        }
+        createAndSubmitChangesets(osmDirs, cb);
+    });
 };
+
+function createAndSubmitChangesets(osmDirs, cb) {
+    var dirs = Object.keys(osmDirs);
+
+    // async.eachLimit(dirs, PARALLEL_SUBMISSIONS, function (dir, cb) {
+    //
+    // }, function ());
+
+
+    async.forEachOfLimit(osmDirs, NUM_PARALLEL_SUBMISSIONS, function (osmFiles, submissionsDir, cb) {
+        createChangeset(osmFiles, submissionsDir, cb);
+    }, function (err) {
+
+    });
+}
+
+function createChangeset(osmFiles, submissionsDir, cb) {
+    
+}
+
+function createOsc() {
+
+}
+

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -12,11 +12,11 @@ module.exports = function (formName, osmApi, cb) {
             cb(err);
             return;
         }
-        createAndSubmitChangesets(osmDirs, cb);
+        createAndSubmitChangesets(osmDirs, osmApi, cb);
     });
 };
 
-function createAndSubmitChangesets(osmDirs, cb) {
+function createAndSubmitChangesets(osmDirs, osmApi, cb) {
     async.forEachOfLimit(osmDirs, NUM_PARALLEL_SUBMISSIONS, createChangesetAndOsc, function (err) {
         if (err) {
             cb(err);
@@ -24,52 +24,77 @@ function createAndSubmitChangesets(osmDirs, cb) {
         }
         cb(null, {done: true}); // or something. gotta do status work
     });
-}
 
-/**
- * These params are essentially the object value and key of osmDirs.
- * This is done behind the scenes of async#forEachOfLimit.
- *
- * @param osmFiles
- * @param submissionsDir
- * @param cb
- */
-function createChangesetAndOsc(osmFiles, submissionsDir, cb) {
-    var changesetXml = generateChangeset(submissionsDir);
-    changesetCreate(changesetXml, function(err, changesetId) {
-        if (err) {
-            cb(err);
-            return;
-        }
-        osm2osc(osmFiles, function (err, oscXml) {
+    /**
+     * These params are essentially the object value and key of osmDirs.
+     * This is done behind the scenes of async#forEachOfLimit.
+     *
+     * @param osmFiles
+     * @param submissionsDir
+     * @param cb
+     */
+    function createChangesetAndOsc(osmFiles, submissionsDir, cb) {
+        var changesetXml = generateChangeset(submissionsDir);
+        changesetCreate(osmApi, changesetXml, function(err, changesetId) {
             if (err) {
                 cb(err);
                 return;
             }
-            changesetUpload(oscXml, function(err, diffResult) {
+            osm2osc(osmFiles, function (err, oscXml) {
                 if (err) {
                     cb(err);
                     return;
                 }
-                // is there anything we should be doing with the diffResult?
-                changesetClose(function (err) {
-                    cb();
+                changesetUpload(osmApi, oscXml, function(err, diffResult) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+                    // is there anything we should be doing with the diffResult?
+                    changesetClose(osmApi, function (err) {
+                        cb();
+                    });
                 });
+                cb();
             });
-            cb();
         });
+    }
+}
+
+function changesetCreate(osmApi, changesetXml, cb) {
+    var opts = {
+        method: 'PUT',
+        headers: {'Content-Type': 'text/xml'},
+        uri: osmApi.server + '/0.6/changeset/create',
+        auth: {
+            user: osmApi.user,
+            pass: osmApi.pass
+        },
+        body: 'changesetXml'
+    };
+
+    request(opts, function (err, response, body) {
+        if (err) {
+            cb(err);
+            return;
+        }
+        if (response.statusCode !== 200) {
+            cb({
+                status: response.statusCode,
+                body: body,
+                msg: 'Could not open changeset on OSM API. ' + body
+            });
+            return;
+        }
+        var changesetId = parseInt(body);
+        cb(null, changesetId);
     });
-
 }
 
-function changesetCreate(changesetXml, cb) {
+function changesetUpload(osmApi, oscXml, cb) {
     
 }
 
-function changesetUpload(oscXml, cb) {
-    
-}
-
-function changesetClose(cb) {
+function changesetClose(osmApi, cb) {
     
 }

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
+var generateChangeset = require('../osm/generate-changeset');
 var osm2osc = require('../osm/osm2osc');
 
 var NUM_PARALLEL_SUBMISSIONS = 4;
@@ -25,7 +26,7 @@ function createAndSubmitChangesets(osmDirs, cb) {
 }
 
 function createChangesetAndOsc(osmFiles, submissionsDir, cb) {
-
+    var changeset = generateChangeset(submissionsDir);
     osm2osc(osmFiles, function (err, oscXmlStr) {
 
     });

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -31,9 +31,13 @@ function submitAllChangesetsForForm(formName, osmApi, cb) {
 }
 
 function createAndSubmitChangesets(osmDirs, osmApi, cb) {
-    // if case no callback is supplied, noop
+
     if (typeof cb !== 'function') {
-        cb = function() {};
+        cb = function(err) {
+            if (err) {
+                console.error('Automatic OMK submission OSM API error. ' + JSON.stringify(err));
+            }
+        };
     }
 
     if (Object.keys(osmDirs).length < 1) {

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -50,12 +50,15 @@ function createAndSubmitChangesets(osmDirs, osmApi, cb) {
             cb(err);
             return;
         }
-        cb(null, {done: true});
+        cb(null, {
+            done: true,
+            msg: 'Completed submitting changeset to OSM.'
+        });
     });
     cb(null, {
         started: true,
-        msg: 'Begun creating and submitting changesets to OSM API.',
-        status: 200
+        msg: 'Began creating and submitting changesets to OSM API.',
+        status: 201
     });
 
     /**
@@ -96,7 +99,6 @@ function createAndSubmitChangesets(osmDirs, osmApi, cb) {
                         cb();
                     });
                 });
-                cb();
             });
         });
     }
@@ -129,6 +131,7 @@ function changesetCreate(osmApi, changesetXml, cb) {
         }
         var changesetId = parseInt(body);
         cb(null, changesetId);
+        console.log('Opened Changeset. ID: ' + changesetId + ' - ' + JSON.stringify(opts));
     });
 }
 
@@ -158,6 +161,7 @@ function changesetUpload(osmApi, changesetId, oscXml, cb) {
             return;
         }
         cb(null, body, changesetId);
+        console.log('Uploaded OSC. ID: ' + changesetId + ' - ' + JSON.stringify(opts));
     });
 }
 
@@ -186,6 +190,7 @@ function changesetClose(osmApi, changesetId, cb) {
             return;
         }
         cb();
+        console.log('Closed Changeset. ID: ' + changesetId + ' - ' + JSON.stringify(opts));
     });
 }
 

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -1,5 +1,6 @@
 var async = require('async');
 var getOsmSubmissionsDirs = require('../helpers/get-osm-submissions-dirs');
+var osm2osc = require('../osm/osm2osc');
 
 var NUM_PARALLEL_SUBMISSIONS = 4;
 
@@ -14,25 +15,23 @@ module.exports = function (formName, osmApi, cb) {
 };
 
 function createAndSubmitChangesets(osmDirs, cb) {
-    var dirs = Object.keys(osmDirs);
-
-    // async.eachLimit(dirs, PARALLEL_SUBMISSIONS, function (dir, cb) {
-    //
-    // }, function ());
-
-
-    async.forEachOfLimit(osmDirs, NUM_PARALLEL_SUBMISSIONS, function (osmFiles, submissionsDir, cb) {
-        createChangeset(osmFiles, submissionsDir, cb);
-    }, function (err) {
-
+    async.forEachOfLimit(osmDirs, NUM_PARALLEL_SUBMISSIONS, createChangesetAndOsc, function (err, changeset, osc) {
+        if (err) {
+            cb(err);
+            return;
+        }
+        submitChangeset(changeset, osc, cb);
     });
 }
 
-function createChangeset(osmFiles, submissionsDir, cb) {
-    
+function createChangesetAndOsc(osmFiles, submissionsDir, cb) {
+
+    osm2osc(osmFiles, function (err, oscXmlStr) {
+
+    });
+
 }
 
-function createOsc() {
+function submitChangeset(changeset, osc, cb) {
 
 }
-

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -1,0 +1,3 @@
+module.exports = function (formName, osmApi, cb) {
+    
+};

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -88,13 +88,13 @@ function createAndSubmitChangesets(osmDirs, osmApi, cb) {
                 changesetUpload(osmApi, changesetId, oscXml, function(err, diffResult, changesetId) {
                     // This isn't truly an error state. Conflicts are common and normal.
                     if (err) {
-                        saveConflict(submissionsDir, err);
+                        saveConflict(submissionsDir, err, changesetId);
                         cb();
                         return;
                     }
 
                     // Saving the diffResult to the submissions dir
-                    saveDiffResult(submissionsDir, diffResult);
+                    saveDiffResult(submissionsDir, diffResult, changesetId);
 
                     changesetClose(osmApi, changesetId, function (err) {
                         if (err) {
@@ -204,15 +204,15 @@ function changesetClose(osmApi, changesetId, cb) {
  * has been successfully submitted, but also to see how IDs potentially have been
  * rewritten.
  */
-function saveDiffResult(submissionsDir, diffResult) {
-    fs.writeFile(submissionsDir + '/diffResult.xml', diffResult, function (err) {
+function saveDiffResult(submissionsDir, diffResult, changesetId) {
+    fs.writeFile(submissionsDir + '/diffResult-' + changesetId + '.xml', diffResult, function (err) {
         // do nothing
     });
 }
 
-function saveConflict(submissionsDir, err) {
+function saveConflict(submissionsDir, err, changesetId) {
     var jsonStr = JSON.stringify(err, null, 2);
-    fs.writeFile(submissionsDir + '/conflict.json', jsonStr, function (err) {
+    fs.writeFile(submissionsDir + '/conflict-' + changesetId + '.json', jsonStr, function (err) {
         // do nothing
     });
     console.log('Conflict uploading changeset. - ' + JSON.stringify(err));

--- a/api/odk/osm/submit-changesets.js
+++ b/api/odk/osm/submit-changesets.js
@@ -70,7 +70,7 @@ function changesetCreate(osmApi, changesetXml, cb) {
             user: osmApi.user,
             pass: osmApi.pass
         },
-        body: 'changesetXml'
+        body: changesetXml
     };
 
     request(opts, function (err, response, body) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/AmericanRedCross/OpenMapKitServer#readme",
   "dependencies": {
+    "async": "^1.5.2",
     "body-parser": "^1.14.2",
     "cors": "^2.7.1",
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-map-kit-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "type-is": "^1.6.10",
     "xform-to-json": "^1.1.1",
     "xml2js": "^0.4.16",
+    "xmlbuilder": "^8.2.2",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "python-shell": "^0.2.0",
     "q": "^1.4.1",
     "recursive-readdir": "^1.3.0",
+    "request": "^2.72.0",
     "serve-index": "^1.7.2",
     "traverse": "^0.6.6",
     "type-is": "^1.6.10",

--- a/settings.js
+++ b/settings.js
@@ -1,8 +1,8 @@
 module.exports = {
     name: 'OpenMapKit Server',
     description: 'OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.',
-    url: 'http://posm.io',
     port: 3210,
     dataDir: __dirname + '/data',
-    pagesDir: __dirname + '/pages'
+    pagesDir: __dirname + '/pages',
+    hostUrl: 'http://omkserver.com'
 };

--- a/settings.js
+++ b/settings.js
@@ -4,5 +4,10 @@ module.exports = {
     port: 3210,
     dataDir: __dirname + '/data',
     pagesDir: __dirname + '/pages',
-    hostUrl: 'http://omkserver.com'
+    hostUrl: 'http://omkserver.com',
+    osmApi: {
+        server: 'https://www.openstreetmap.org/api',
+        user: 'POSM',
+        pass: ''
+    }
 };

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,7 @@
 module.exports = {
     name: 'OpenMapKit Server',
     description: 'OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.',
+    url: 'http://posm.io',
     port: 3210,
     dataDir: __dirname + '/data',
     pagesDir: __dirname + '/pages'


### PR DESCRIPTION
Closes #63 

Closes https://github.com/AmericanRedCross/posm/issues/125

When:

1. the user submits a survey to OMK Server from ODK Collect or 
2. the `/omk/odk/submit-changesets/<form>` gets hit, 

changesets are submitted. 

It’s not immediate, because OSM API is not very fast, and I can only do them 3 at a time. The progress is only console output right now. the `difResult-<changeset_id>.xml` xml is written to the submission directory if it succeeds, and a `conflict-<changeset_id>.json` is written instead if there is a conflict. This should be straightforward for a Red Cross GIS person to do, but I just need to show you. Also, we could put in a _Sync_ button and pipe the console output via websockets just so there is _slight_ UI. I think anything further shouldn’t be this phase of work. We also have to figure out what to do with OMK iD, being that it is redundant at this point. I’ll go more into the details when we meet. 

cc/ @jharpster @dalekunce  @danielduhh  @mojodna 