### PR TITLE
Fix get json submissions

### DIFF
--- a/api/odk/controllers/get-json-submissions.js
+++ b/api/odk/controllers/get-json-submissions.js
@@ -51,6 +51,7 @@ module.exports = function (req, res, next) {
             if (submissionDir[0] === '.' || submissionDir.indexOf('.txt') > 0) {
                 ++count;
                 sendResponse(len, count, aggregate, []);
+                return;
             }
             var dataFile = dir + '/' + submissionDir + '/data.json';
             var dataContent = '';
@@ -63,7 +64,8 @@ module.exports = function (req, res, next) {
                     // console.log('objects', obj)
                     ++count;
                     aggregate.push(obj);
-                    sendResponse(len, count, aggregate, [])
+                    sendResponse(len, count, aggregate, []);
+                    return;
                 });
             } catch(e) {
                 dataErrors.push({
@@ -72,6 +74,7 @@ module.exports = function (req, res, next) {
                         err: e
                     });
                 sendResponse(len, count, aggregate, dataErrors);
+                return;
             }
         });
     });
@@ -84,7 +87,6 @@ module.exports = function (req, res, next) {
             } else {
                 res.status(200).json(data);
             }
-        return;
-    }
+        }
     }
 };

--- a/api/odk/controllers/get-json-submissions.js
+++ b/api/odk/controllers/get-json-submissions.js
@@ -65,7 +65,6 @@ module.exports = function (req, res, next) {
                     ++count;
                     aggregate.push(obj);
                     sendResponse(len, count, aggregate, []);
-                    return;
                 });
             } catch(e) {
                 dataErrors.push({
@@ -74,7 +73,6 @@ module.exports = function (req, res, next) {
                         err: e
                     });
                 sendResponse(len, count, aggregate, dataErrors);
-                return;
             }
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-map-kit-server",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "description": "OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a quick fix to @ahmedOpeyemi 's JSONStream work. When running the server on a Mac, the submissions directory gets a `.DS_Store` file. Since this isn't a directory, we need to skip looking in this path. This worked before, but there was just a missing return in the new code. This added return prevents us from trying to open the non-existent `.DS_Store` directory.