### PR TITLE
API Pagination & Submissions Page Performance

### DIFF
--- a/api/odk/controllers/get-csv-submissions.js
+++ b/api/odk/controllers/get-csv-submissions.js
@@ -8,7 +8,7 @@ var json2csv = require('json2csv');
  */
 module.exports = function (req, res, next) {
 
-    aggregate(req.params.formName, errorCallback, aggregateCallback);
+    aggregate(req, errorCallback, aggregateCallback);
 
     function errorCallback(err) {
         res.status(err.status).json(err);

--- a/api/odk/controllers/get-csv-submissions.js
+++ b/api/odk/controllers/get-csv-submissions.js
@@ -8,14 +8,17 @@ var json2csv = require('json2csv');
  */
 module.exports = function (req, res, next) {
 
-    aggregate(req, errorCallback, aggregateCallback);
+    var opts = {
+        formName: req.params.formName,
+        limit: req.query.limit,
+        offset: req.query.offset
+    };
 
-    function errorCallback(err) {
-        res.status(err.status).json(err);
-    }
-
-    function aggregateCallback(aggregate) {
-
+    aggregate(opts, errorCallback, function (err, aggregate) {
+        if (err) {
+            res.status(err.status).json(err);
+            return;
+        }
         try {
             var csv = json2csv({
                 data: aggregate,
@@ -33,8 +36,7 @@ module.exports = function (req, res, next) {
                 err: err
             });
         }
-
-    }
+    });
 
 };
 

--- a/api/odk/controllers/get-csv-submissions.js
+++ b/api/odk/controllers/get-csv-submissions.js
@@ -14,7 +14,7 @@ module.exports = function (req, res, next) {
         offset: req.query.offset
     };
 
-    aggregate(opts, errorCallback, function (err, aggregate) {
+    aggregate(opts, function (err, aggregate) {
         if (err) {
             res.status(err.status).json(err);
             return;

--- a/api/odk/controllers/get-json-submissions.js
+++ b/api/odk/controllers/get-json-submissions.js
@@ -7,14 +7,18 @@ var aggregate = require('../helpers/aggregate-submissions');
  */
 module.exports = function (req, res, next) {
 
-    aggregate(req, errorCallback, aggregateCallback);
+    var opts = {
+        formName: req.params.formName,
+        limit: req.query.limit,
+        offset: req.query.offset
+    };
 
-    function errorCallback(err) {
-        res.status(err.status).json(err);
-    }
-
-    function aggregateCallback(aggregate) {
+    aggregate(opts, function(err, aggregate) {
+        if (err) {
+            res.status(err.status).json(err);
+            return;
+        }
         res.status(200).json(aggregate);
-    }
+    });
 
 };

--- a/api/odk/controllers/get-json-submissions.js
+++ b/api/odk/controllers/get-json-submissions.js
@@ -7,7 +7,7 @@ var aggregate = require('../helpers/aggregate-submissions');
  */
 module.exports = function (req, res, next) {
 
-    aggregate(req.params.formName, errorCallback, aggregateCallback);
+    aggregate(req, errorCallback, aggregateCallback);
 
     function errorCallback(err) {
         res.status(err.status).json(err);

--- a/jekyll/_sass/_layout.scss
+++ b/jekyll/_sass/_layout.scss
@@ -6,7 +6,6 @@
 
 // Page container
 .page-content{
-  //max-width: 1200px;
   overflow-x: auto;
 }
 

--- a/jekyll/js/submissions/index.js
+++ b/jekyll/js/submissions/index.js
@@ -128,11 +128,7 @@ function doCSV(json) {
     // show raw data if people really want it
     $(".csv textarea").val(csv);
 
-    // download link to entire CSV as data
-    // thanks to http://jsfiddle.net/terryyounghk/KPEGU/
-    // and http://stackoverflow.com/questions/14964035/how-to-export-javascript-array-info-to-csv-on-client-side
-    var uri = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
-    $("#downloadCsv").attr("href", uri).attr("download", getParam('form') + ".csv");
+    $("#downloadCsv").attr("href", OMK.csvUrl()).attr("download", getParam('form') + ".csv");
     $("#downloadJson").attr("href", OMK.jsonUrl()).attr("download", getParam('form') + ".json");
 }
 

--- a/jekyll/js/submissions/index.js
+++ b/jekyll/js/submissions/index.js
@@ -19,7 +19,7 @@ function parseObject(obj, path) {
     if (type == "array" || type == "object") {
         var d = {};
         for (var i in obj) {
-            var newD = parseObject(obj[i], path + i + "/");
+            var newD = parseObject(obj[i], path + i + ".");
             $.extend(d, newD);
         }
         return d;
@@ -102,28 +102,27 @@ function renderCSV(objects) {
     table.appendChild(thead);
     table.appendChild(tbody);
 
-    //register the mdl Table
-    setTimeout(function () {
-        componentHandler.upgradeAllRegistered();
-    }, 1000);
-
-    $('#submission-table').DataTable();
+    OMK._dataTable = $('#submission-table').DataTable({
+        "deferRender": true
+    });
 }
 
-function doCSV(json) {
-    // 1) find the primary array to iterate over
-    // 2) for each item in that array, recursively flatten it into a tabular object
-    // 3) turn that tabular object into a CSV row using jquery-csv
+function createFlatObjects(json) {
     var inArray = arrayFrom(json);
 
     var outArray = [];
-    for (var row in inArray)
+    for (var row in inArray) {
         outArray[outArray.length] = parseObject(inArray[row]);
+    }
+    return outArray;
+}
 
+function doCSV(json) {
+    var flatObjects = createFlatObjects(json);
 
-    var csv = $.csv.fromObjects(outArray);
+    var csv = $.csv.fromObjects(flatObjects);
     // excerpt and render first 10 rows
-    renderCSV(outArray);
+    renderCSV(flatObjects);
     showCSV(true);
 
     // show raw data if people really want it
@@ -201,7 +200,10 @@ $(function () {
 
     // get form name & number of submission
     OMK.fetch(function () {
-        OMK.getFormMetaData();
+        $("#submissionPagespinner").hide();
+        $(".areas").show();
+        $(".csv").show();
+        $("#submissionCard").show();
     });
 });
 

--- a/jekyll/js/submissions/omk.js
+++ b/jekyll/js/submissions/omk.js
@@ -7,7 +7,22 @@ OMK.fetch = function (cb) {
     OMK.getFormMetaData(function(metadata) {
         OMK.fetchJSON(OMK.jsonUrl() + '?offset=0&limit=' + OMK._PAGINATION_LIMIT, function() {
             cb();
+            // pagination too slow
             // OMK.paginate(metadata.total);
+
+            if (OMK._PAGINATION_LIMIT < metadata.total) {
+                var toastOptions = {
+                    style: {
+                        main: {
+                            background: "#f2dede",
+                            color: "#a94442",
+                            'box-shadow': '0 0 0px'
+                        }
+                    }
+                };
+                iqwerty.toast.Toast('The data set is large. We have loaded ' + OMK._PAGINATION_LIMIT +
+                    ' of ' + metadata.total + ' submissions. Download the ODK CSV or JSON data to get the rest.', toastOptions);
+            }
         });
     });
 };
@@ -21,6 +36,11 @@ OMK.jsonUrl = function () {
         }
     }
     return json;
+};
+
+OMK.csvUrl = function () {
+    var form = getParam('form');
+    return OMK.omkServerUrl() + '/omk/odk/submissions/' + form + '.csv';
 };
 
 //Function to capitalise first character for strings
@@ -49,8 +69,14 @@ OMK.jsonPaginationUrl = function() {
     return OMK.jsonUrl() + '?offset=' + OMK._paginationOffset + '&limit=' + OMK._PAGINATION_LIMIT;
 };
 
+/**
+ * Doing recursive loads of pagination of data is quite slow and halts the UI.
+ * We're going to disable this for now...
+ *
+ * @param total
+ */
 OMK.paginate = function (total) {
-    setTimeout(function() {
+    setTimeout(function() { // timeouts dont completely fix the UI from halting...
         OMK._paginationOffset += OMK._PAGINATION_LIMIT;
         if (OMK._paginationOffset < total) {
             $.get(OMK.jsonPaginationUrl(), function (data, status, xhr) {

--- a/jekyll/submissions/index.html
+++ b/jekyll/submissions/index.html
@@ -36,9 +36,6 @@ omk: omk
                     </a>
 
                     <ul class="mdl-menu mdl-menu--bottom-right- mdl-js-menu mdl-js-ripple-effect" for="odk-options">
-                        <a href="#">
-                            <li class="showRawCSV mdl-menu__item">View CSV</li>
-                        </a>
                         <a id="downloadCsv" download="data.csv" href="#" class="download">
                             <li class="mdl-menu__item">Download CSV</li>
                         </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-map-kit-server",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-map-kit-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "OpenMapKit Server is the lightweight server component of OpenMapKit that handles the collection and aggregation of OpenStreetMap and OpenDataKit data.",
   "main": "index.js",
   "scripts": {

--- a/pages/js/submissions/index.js
+++ b/pages/js/submissions/index.js
@@ -128,11 +128,7 @@ function doCSV(json) {
     // show raw data if people really want it
     $(".csv textarea").val(csv);
 
-    // download link to entire CSV as data
-    // thanks to http://jsfiddle.net/terryyounghk/KPEGU/
-    // and http://stackoverflow.com/questions/14964035/how-to-export-javascript-array-info-to-csv-on-client-side
-    var uri = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
-    $("#downloadCsv").attr("href", uri).attr("download", getParam('form') + ".csv");
+    $("#downloadCsv").attr("href", OMK.csvUrl()).attr("download", getParam('form') + ".csv");
     $("#downloadJson").attr("href", OMK.jsonUrl()).attr("download", getParam('form') + ".json");
 }
 

--- a/pages/js/submissions/index.js
+++ b/pages/js/submissions/index.js
@@ -19,7 +19,7 @@ function parseObject(obj, path) {
     if (type == "array" || type == "object") {
         var d = {};
         for (var i in obj) {
-            var newD = parseObject(obj[i], path + i + "/");
+            var newD = parseObject(obj[i], path + i + ".");
             $.extend(d, newD);
         }
         return d;
@@ -102,28 +102,27 @@ function renderCSV(objects) {
     table.appendChild(thead);
     table.appendChild(tbody);
 
-    //register the mdl Table
-    setTimeout(function () {
-        componentHandler.upgradeAllRegistered();
-    }, 1000);
-
-    $('#submission-table').DataTable();
+    OMK._dataTable = $('#submission-table').DataTable({
+        "deferRender": true
+    });
 }
 
-function doCSV(json) {
-    // 1) find the primary array to iterate over
-    // 2) for each item in that array, recursively flatten it into a tabular object
-    // 3) turn that tabular object into a CSV row using jquery-csv
+function createFlatObjects(json) {
     var inArray = arrayFrom(json);
 
     var outArray = [];
-    for (var row in inArray)
+    for (var row in inArray) {
         outArray[outArray.length] = parseObject(inArray[row]);
+    }
+    return outArray;
+}
 
+function doCSV(json) {
+    var flatObjects = createFlatObjects(json);
 
-    var csv = $.csv.fromObjects(outArray);
+    var csv = $.csv.fromObjects(flatObjects);
     // excerpt and render first 10 rows
-    renderCSV(outArray);
+    renderCSV(flatObjects);
     showCSV(true);
 
     // show raw data if people really want it
@@ -201,7 +200,10 @@ $(function () {
 
     // get form name & number of submission
     OMK.fetch(function () {
-        OMK.getFormMetaData();
+        $("#submissionPagespinner").hide();
+        $(".areas").show();
+        $(".csv").show();
+        $("#submissionCard").show();
     });
 });
 

--- a/pages/js/submissions/omk.js
+++ b/pages/js/submissions/omk.js
@@ -7,7 +7,22 @@ OMK.fetch = function (cb) {
     OMK.getFormMetaData(function(metadata) {
         OMK.fetchJSON(OMK.jsonUrl() + '?offset=0&limit=' + OMK._PAGINATION_LIMIT, function() {
             cb();
+            // pagination too slow
             // OMK.paginate(metadata.total);
+
+            if (OMK._PAGINATION_LIMIT < metadata.total) {
+                var toastOptions = {
+                    style: {
+                        main: {
+                            background: "#f2dede",
+                            color: "#a94442",
+                            'box-shadow': '0 0 0px'
+                        }
+                    }
+                };
+                iqwerty.toast.Toast('The data set is large. We have loaded ' + OMK._PAGINATION_LIMIT +
+                    ' of ' + metadata.total + ' submissions. Download the ODK CSV or JSON data to get the rest.', toastOptions);
+            }
         });
     });
 };
@@ -21,6 +36,11 @@ OMK.jsonUrl = function () {
         }
     }
     return json;
+};
+
+OMK.csvUrl = function () {
+    var form = getParam('form');
+    return OMK.omkServerUrl() + '/omk/odk/submissions/' + form + '.csv';
 };
 
 //Function to capitalise first character for strings
@@ -49,8 +69,14 @@ OMK.jsonPaginationUrl = function() {
     return OMK.jsonUrl() + '?offset=' + OMK._paginationOffset + '&limit=' + OMK._PAGINATION_LIMIT;
 };
 
+/**
+ * Doing recursive loads of pagination of data is quite slow and halts the UI.
+ * We're going to disable this for now...
+ *
+ * @param total
+ */
 OMK.paginate = function (total) {
-    setTimeout(function() {
+    setTimeout(function() { // timeouts dont completely fix the UI from halting...
         OMK._paginationOffset += OMK._PAGINATION_LIMIT;
         if (OMK._paginationOffset < total) {
             $.get(OMK.jsonPaginationUrl(), function (data, status, xhr) {

--- a/pages/submissions/index.html
+++ b/pages/submissions/index.html
@@ -83,9 +83,6 @@
                     </a>
 
                     <ul class="mdl-menu mdl-menu--bottom-right- mdl-js-menu mdl-js-ripple-effect" for="odk-options">
-                        <a href="#">
-                            <li class="showRawCSV mdl-menu__item">View CSV</li>
-                        </a>
                         <a id="downloadCsv" download="data.csv" href="#" class="download">
                             <li class="mdl-menu__item">Download CSV</li>
                         </a>


### PR DESCRIPTION
I've made a couple of improvements that allows the UI to get submissions for forms with a large number of responses.

## API Pagination

I've added pagination to the REST API. I'm using the most common nomenclature of using query params of `limit` and `offset`. For example:

```
http://localhost:3210/omk/odk/submissions/sl_buildings.json?offset=25&limit=10
```

This will get me 10 submissions starting at the index of 25. Responses are sorted alphabetically by the UUID.

## Submissions Page Fetch Limit

Right now, I've limited the submissions page to fetch at maximum 5000 submissions to be shown in the table. Any more takes a bit too long. I experimented with iteratively paginating more data into the JQuery Datatable, but this nonetheless needs to modify the DOM, so it can't be done in a thread.

We easily hit the limitations of working in the browser. The right solution would be to implement pagination of a table with the REST API. I'm not seeing a straightforward way of doing this with JQuery Datatables, so we'd want to go with something else.

This gives room for a good smaller project of revamping the submissions table UI. Perhaps a React project?

---

So, right now, if the number of responses is over 5000, we just get 5000 and notify the user in a toast at the bottom. You can get the complete dataset by downloading the JSON, CSV, or OSM. Also note that the CSV download actually hits the server's CSV endpoint instead of having the browser do the work.
